### PR TITLE
Redesign hero section with panther background

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -10,58 +10,68 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="min-h-screen flex items-center justify-center relative overflow-hidden bg-background">
-      <div className="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-        {/* Left side - Text content */}
-        <div className="text-left space-y-8 animate-slide-up">
-          <h1 className="font-heading text-5xl lg:text-7xl font-bold leading-tight">
-            <span className="gradient-text">КРАСИВЫЕ НОГТИ —</span>
-            <br />
-            <span className="gradient-text">ЭТО ПРОСТО</span>
-          </h1>
-          
-          <div className="space-y-4 text-lg lg:text-xl">
-            <p className="text-foreground">
-              ЕСЛИ ВЫ ИСКАЛИ <span className="text-primary font-semibold">ЛУЧШЕГО МАСТЕРА</span>
-            </p>
-            <p className="text-foreground">
-              ПО УХОДУ ЗА СВОИМИ НОГТЯМИ В
-            </p>
-            <p className="text-foreground">
-              ГОРОДЕ
-            </p>
-            <p className="text-primary text-3xl font-bold font-heading">
-              РОСТОВ - НА - ДОНУ
-            </p>
-            <p className="text-foreground">
-              ТО ВЫ ЕГО НАШЛИ
-            </p>
-          </div>
+    <section className="relative isolate flex min-h-screen items-center overflow-hidden bg-[#050505]">
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 bg-[#050505]" aria-hidden="true" />
+        <img
+          src={pantherHero}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute right-[-12%] top-1/2 hidden h-[125%] max-w-none -translate-y-1/2 object-contain md:block"
+        />
+        <img
+          src={pantherHero}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 block h-full w-full object-cover object-right opacity-30 md:hidden"
+        />
+        <div
+          className="absolute inset-0 bg-gradient-to-r from-[#050505] via-[#050505]/95 to-transparent"
+          aria-hidden="true"
+        />
+      </div>
 
-          <Button 
-            onClick={scrollToContact}
-            className="btn-hero text-xl px-12 py-6 mt-8"
-          >
-            ЗАПИСАТЬСЯ
-          </Button>
-        </div>
-
-        {/* Right side - Panther image */}
-        <div className="flex justify-center lg:justify-end animate-float">
-          <div className="relative">
-            <img 
-              src={pantherHero} 
-              alt="Элегантная пантера - символ красоты и изящества" 
-              className="w-full max-w-lg h-auto object-cover rounded-3xl shadow-2xl"
-            />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-transparent rounded-3xl"></div>
+      <div className="container relative z-10 mx-auto px-4 py-20 lg:py-32">
+        <div className="max-w-xl rounded-[40px] border border-primary/20 bg-background/80 p-8 sm:p-12 shadow-2xl backdrop-blur-md text-left animate-slide-up">
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.55em] text-muted-foreground">
+              ЯНА ПИЛИТ
+            </p>
+            <h1 className="font-heading text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight uppercase">
+              <span className="gradient-text">КРАСИВЫЕ НОГТИ —</span>
+              <br />
+              <span className="gradient-text">ЭТО ПРОСТО</span>
+            </h1>
+            <div className="space-y-2 text-lg sm:text-xl font-medium text-foreground">
+              <p>
+                ЕСЛИ ВЫ ИСКАЛИ{' '}
+                <span className="text-primary font-semibold">ЛУЧШЕГО МАСТЕРА</span>
+              </p>
+              <p>ПО УХОДУ ЗА СВОИМИ НОГТЯМИ В</p>
+              <p>ГОРОДЕ</p>
+              <p className="text-primary text-3xl font-bold font-heading tracking-wide">
+                РОСТОВ - НА - ДОНУ
+              </p>
+              <p>ТО ВЫ ЕГО НАШЛИ</p>
+            </div>
+            <Button
+              onClick={scrollToContact}
+              className="btn-hero text-lg sm:text-xl px-10 sm:px-12 py-5 sm:py-6 mt-4"
+            >
+              ЗАПИСАТЬСЯ
+            </Button>
           </div>
         </div>
       </div>
 
-      {/* Decorative background elements */}
-      <div className="absolute top-20 left-10 w-20 h-20 bg-primary/10 rounded-full blur-xl animate-pulse"></div>
-      <div className="absolute bottom-20 right-10 w-32 h-32 bg-secondary/10 rounded-full blur-xl animate-pulse delay-1000"></div>
+      <div
+        className="absolute -left-24 top-24 hidden h-64 w-64 rounded-full bg-primary/20 blur-3xl md:block"
+        aria-hidden="true"
+      />
+      <div
+        className="absolute bottom-10 left-1/3 h-40 w-40 rounded-full bg-secondary/30 blur-3xl"
+        aria-hidden="true"
+      />
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- restyle the hero block to display the panther image as a right-aligned background element
- wrap the hero content in a highlighted information card with headline, supporting copy, and sign-up button
- add subtle lighting accents to complement the new layout without affecting the header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1bb0cea74832190c38865facd93fa