### PR TITLE
Expand gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,23 @@
+# Dependency directories
+node_modules/
+.pnp
+.pnp.js
+
+# Lockfiles created by alternative package managers
+bun.lockb
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Build output
+dist/
+dist-ssr/
+build/
+.output/
+.next/
+
 # Logs
-logs
+logs/
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -7,18 +25,37 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
+# Testing and coverage
+coverage/
+.nyc_output/
+cypress/videos/
+cypress/screenshots/
+playwright-report/
+
+# Environment files
+.env*
+!.env.example
+!.env.*.example
 *.local
 
-# Editor directories and files
-.vscode/*
+# Cache directories
+.cache/
+.parcel-cache/
+.eslintcache
+.stylelintcache
+.tsbuildinfo
+
+# IDE and editor settings
+.vscode/
 !.vscode/extensions.json
-.idea
+.idea/
 .DS_Store
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
+
+# Miscellaneous
+Thumbs.db
+*.iml


### PR DESCRIPTION
## Summary
- expand the gitignore file to cover additional dependencies, builds, caches, and environment artifacts that should not be committed

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d83f72630083218d3e657df0a8a192